### PR TITLE
fix Modelfile: remove invalid shell commands

### DIFF
--- a/Modelfile
+++ b/Modelfile
@@ -3,6 +3,3 @@ PARAMETER num_ctx 16384
 PARAMETER temperature 0.7
 PARAMETER top_k 10
 PARAMETER top_p 0.9
-export OLLAMA_GPU_LAYERS=80
-export OLLAMA_NUM_THREAD=8
-ollama run metatron-qwen


### PR DESCRIPTION
## Summary
- Removed invalid shell commands (`export OLLAMA_GPU_LAYERS`, `export OLLAMA_NUM_THREAD`, `ollama run`) from the Modelfile
- These are not valid Ollama Modelfile instructions and cause errors when building the model

## Test plan
- [ ] Run `ollama create metatron-qwen -f Modelfile` and confirm it succeeds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)