### PR TITLE
feat: Multi-provider LLM support (Ollama, OpenAI, Claude, Gemini)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# ─────────────────────────────────────────────
+# METATRON — Environment Configuration
+# ─────────────────────────────────────────────
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# Ollama (local) works out of the box with no API key.
+# To use cloud providers, add the corresponding API key.
+# ─────────────────────────────────────────────
+
+# Active LLM provider: ollama | anthropic | openai | google
+ACTIVE_PROVIDER=ollama
+
+# Model name (depends on provider)
+# Ollama:     metatron-qwen
+# Anthropic:  claude-sonnet-4-20250514, claude-opus-4-20250514
+# OpenAI:     gpt-4.1-mini (recommended), gpt-4.1, gpt-4.1-nano
+# Google:     gemini-2.5-pro-preview-05-06, gemini-2.5-flash-preview-04-17
+ACTIVE_MODEL=metatron-qwen
+
+# ─── API Keys ────────────────────────────────
+# Only fill the key for the provider you're using.
+
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+
+# ─── Ollama (local) ─────────────────────────
+OLLAMA_URL=http://localhost:11434/api/chat
+
+# ─── Generation Parameters ───────────────────
+MAX_TOKENS=8192
+MAX_TOOL_LOOPS=9
+TEMPERATURE=0.7
+LLM_TIMEOUT=600
+
+# ─── Database ────────────────────────────────
+DB_HOST=localhost
+DB_USER=metatron
+DB_PASSWORD=123
+DB_NAME=metatron

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+.env
 reports/
 exports/
 venv/
 __pycache__/
-*.pyc# Byte-compiled / optimized / DLL files
+*.pyc
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]
 *$py.class

--- a/config.py
+++ b/config.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+METATRON - config.py
+Centralized configuration loaded from .env file.
+All settings live here — no more hardcoded values scattered across modules.
+"""
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+# load .env from project root
+_env_path = Path(__file__).resolve().parent / ".env"
+load_dotenv(_env_path)
+
+
+# ─────────────────────────────────────────────
+# LLM PROVIDER
+# ─────────────────────────────────────────────
+
+ACTIVE_PROVIDER = os.getenv("ACTIVE_PROVIDER", "ollama")   # ollama | anthropic | openai | google
+ACTIVE_MODEL    = os.getenv("ACTIVE_MODEL",    "metatron-qwen")
+
+# API keys (empty string = not configured)
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+OPENAI_API_KEY    = os.getenv("OPENAI_API_KEY",    "")
+GOOGLE_API_KEY    = os.getenv("GOOGLE_API_KEY",    "")
+
+# Ollama
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/chat")
+
+# Generation parameters
+MAX_TOKENS     = int(os.getenv("MAX_TOKENS",     "8192"))
+MAX_TOOL_LOOPS = int(os.getenv("MAX_TOOL_LOOPS", "9"))
+TEMPERATURE    = float(os.getenv("TEMPERATURE",   "0.7"))
+LLM_TIMEOUT    = int(os.getenv("LLM_TIMEOUT",    "600"))
+
+
+# ─────────────────────────────────────────────
+# DATABASE
+# ─────────────────────────────────────────────
+
+DB_HOST     = os.getenv("DB_HOST",     "localhost")
+DB_USER     = os.getenv("DB_USER",     "metatron")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "123")
+DB_NAME     = os.getenv("DB_NAME",     "metatron")
+
+
+# ─────────────────────────────────────────────
+# PROVIDER CATALOG
+# ─────────────────────────────────────────────
+
+PROVIDERS = {
+    "ollama": {
+        "name":    "Ollama (Local)",
+        "models":  ["metatron-qwen"],
+        "key_var": None,
+    },
+    "anthropic": {
+        "name":    "Anthropic (Claude)",
+        "models":  ["claude-sonnet-4-20250514", "claude-opus-4-20250514", "claude-haiku-4-20250514"],
+        "key_var": "ANTHROPIC_API_KEY",
+    },
+    "openai": {
+        "name":    "OpenAI",
+        "models":  ["gpt-4.1-mini", "gpt-4.1", "gpt-4.1-nano"],
+        "key_var": "OPENAI_API_KEY",
+    },
+    "google": {
+        "name":    "Google (Gemini)",
+        "models":  ["gemini-2.5-pro-preview-05-06", "gemini-2.5-flash-preview-04-17", "gemini-2.0-flash"],
+        "key_var": "GOOGLE_API_KEY",
+    },
+}
+
+
+def get_api_key(provider: str) -> str:
+    """Get the API key for a provider, or empty string if not set."""
+    key_var = PROVIDERS.get(provider, {}).get("key_var")
+    if key_var is None:
+        return ""
+    return globals().get(key_var, "")
+
+
+def has_api_key(provider: str) -> bool:
+    """Check if a provider has a configured API key."""
+    if provider == "ollama":
+        return True
+    return bool(get_api_key(provider))

--- a/db.py
+++ b/db.py
@@ -7,6 +7,7 @@ Database: metatron
 
 import mysql.connector
 from datetime import datetime
+from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME
 
 
 # ─────────────────────────────────────────────
@@ -14,12 +15,12 @@ from datetime import datetime
 # ─────────────────────────────────────────────
 
 def get_connection():
-    """Returns a MariaDB connection. No password (local setup)."""
+    """Returns a MariaDB connection using config.py settings."""
     return mysql.connector.connect(
-        host="localhost",
-        user="metatron",
-        password="123",
-        database="metatron"
+        host=DB_HOST,
+        user=DB_USER,
+        password=DB_PASSWORD,
+        database=DB_NAME
     )
 
 

--- a/export.py
+++ b/export.py
@@ -3,6 +3,7 @@
 import os
 import datetime
 import mysql.connector
+from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME
 from reportlab.lib.pagesizes import A4
 from reportlab.lib import colors
 from reportlab.lib.units import mm
@@ -29,10 +30,10 @@ RISK_COLORS = {
 
 def get_connection():
     return mysql.connector.connect(
-        host="localhost",
-        user="metatron",
-        password="123",
-        database="metatron"
+        host=DB_HOST,
+        user=DB_USER,
+        password=DB_PASSWORD,
+        database=DB_NAME
     )
 
 

--- a/llm.py
+++ b/llm.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
 """
 METATRON - llm.py
-Ollama interface for metatron-qwen model.
+LLM interface — provider-agnostic.
 Builds prompts, handles AI responses, runs tool dispatch loop.
-Model: metatron-qwen (fine-tuned from huihui_ai/qwen3.5-abliterated:9b)
+Supports: Ollama (local), Anthropic (Claude), OpenAI, Google (Gemini).
+Provider selection is handled by providers.py + config.py.
 """
 
 import re
 import requests
-import json
 from tools import run_tool_by_command, run_nmap, run_curl_headers
 from search import handle_search_dispatch
+from providers import get_provider
+import config
 
-OLLAMA_URL  = "http://localhost:11434/api/chat"
-MODEL_NAME  = "metatron-qwen"
-MAX_TOKENS = 8192
-MAX_TOOL_LOOPS = 9   # max times AI can call tools per session
-OLLAMA_TIMEOUT = 600 
+MAX_TOOL_LOOPS = config.MAX_TOOL_LOOPS
 
 # ─────────────────────────────────────────────
 # SYSTEM PROMPT
@@ -65,37 +63,18 @@ IMPORTANT RULES FOR ACCURACY:
 
 
 # ─────────────────────────────────────────────
-# OLLAMA API CALL
+# LLM API CALL (provider-agnostic)
 # ─────────────────────────────────────────────
 
-def ask_ollama(messages: list) -> str:
-    try:
-        payload = {
-            "model":  MODEL_NAME,
-            "messages": messages,
-            "stream": False,
-            "options": {
-                "num_predict": MAX_TOKENS,
-                "temperature": 0.7,
-                "top_p": 0.9,
-            }
-        }
-        print(f"\n[*] Sending to {MODEL_NAME}...")
-        resp = requests.post(OLLAMA_URL, json=payload, timeout=OLLAMA_TIMEOUT)
-        resp.raise_for_status()
-        data = resp.json()
-        response = data.get("message", {}).get("content", "").strip()
-        if not response:
-            return "[!] Model returned empty response."
-        return response
-    except requests.exceptions.ConnectionError:
-        return "[!] Cannot connect to Ollama. Is it running? Try: ollama serve"
-    except requests.exceptions.Timeout:
-        return "[!] Ollama timed out. Model may be loading, try again."
-    except requests.exceptions.HTTPError as e:
-        return f"[!] Ollama HTTP error: {e}"
-    except Exception as e:
-        return f"[!] Unexpected error: {e}"
+def ask_llm(messages: list, provider_name: str = None,
+            model: str = None) -> str:
+    """
+    Send messages to the active LLM provider.
+    provider_name/model: optional overrides for per-scan switching.
+    Returns the AI response string.
+    """
+    provider = get_provider(name=provider_name, model=model)
+    return provider.send(messages)
 
 
 # ─────────────────────────────────────────────
@@ -119,35 +98,32 @@ def extract_tool_calls(response: str) -> list:
 
     return calls
 
-def summarize_tool_output(raw_output: str) -> str:
+def summarize_tool_output(raw_output: str, provider_name: str = None,
+                          model: str = None) -> str:
     """
     Compress raw tool output into security-relevant bullet points
     before injecting into the LLM context.
     Keeps context size manageable across rounds.
+    Uses the active provider (or override) for summarization.
     """
     if len(raw_output) < 500:
         return raw_output
 
     try:
-        payload = {
-            "model":  MODEL_NAME,
-            "messages": [
-    {"role": "system", "content": "You are a security data compressor. Extract only security-relevant facts. Return maximum 15 bullet points. Plain text only. No markdown."},
-    {"role": "user", "content": f"Compress this tool output:\n{raw_output[:6000]}"} ],
-            "stream": False,
-            "options": {
-                "num_predict": 512,
-                "temperature": 0.2,
-                "top_p": 0.9,
-            }
-        }
-        resp = requests.post(OLLAMA_URL, json=payload, timeout=120)
-        resp.raise_for_status()
-        summary = resp.json().get("message", {}).get("content", "").strip()
+        summarizer = get_provider(
+            name=provider_name, model=model,
+            max_tokens=512, temperature=0.2,
+        )
+        messages = [
+            {"role": "system", "content": "You are a security data compressor. Extract only security-relevant facts. Return maximum 15 bullet points. Plain text only. No markdown."},
+            {"role": "user", "content": f"Compress this tool output:\n{raw_output[:6000]}"},
+        ]
+        summary = summarizer.send(messages)
         return summary if summary else raw_output
     except Exception:
         return raw_output
-def run_tool_calls(calls: list) -> str:
+def run_tool_calls(calls: list, provider_name: str = None,
+                   model: str = None) -> str:
     """
     Execute all tool/search calls and return combined results string.
     """
@@ -165,7 +141,9 @@ def run_tool_calls(calls: list) -> str:
         else:
             output = f"[!] Unknown call type: {call_type}"
 
-        compressed = summarize_tool_output(output.strip())
+        compressed = summarize_tool_output(output.strip(),
+                                           provider_name=provider_name,
+                                           model=model)
         results += f"\n[{call_type} RESULT: {call_content}]\n"
         results += "─" * 40 + "\n"
         results += compressed + "\n"
@@ -296,7 +274,26 @@ def parse_summary(response: str) -> str:
 # MAIN ANALYSIS FUNCTION
 # ─────────────────────────────────────────────
 
-def analyse_target(target: str, raw_scan: str) -> dict:
+def analyse_target(target: str, raw_scan: str,
+                   provider_name: str = None, model: str = None) -> dict:
+    """
+    Full analysis pipeline:
+    1. Build initial prompt with scan data
+    2. Send to active LLM provider
+    3. Run tool dispatch loop if AI requests tools
+    4. Parse structured output
+    5. Return everything ready for db.py to save
+
+    provider_name/model: optional overrides for per-scan switching.
+
+    Returns dict with:
+      - full_response   : complete AI text
+      - vulnerabilities : list of parsed vuln dicts
+      - exploits        : list of parsed exploit dicts
+      - risk_level      : CRITICAL/HIGH/MEDIUM/LOW
+      - summary         : short summary text
+      - raw_scan        : original scan dump
+    """
     messages = [
         {
             "role": "system",
@@ -317,7 +314,7 @@ List all vulnerabilities, fixes, and suggest exploits where applicable."""
     final_response = ""
 
     for loop in range(MAX_TOOL_LOOPS):
-        response = ask_ollama(messages)
+        response = ask_llm(messages, provider_name=provider_name, model=model)
 
         print(f"\n{'─'*60}")
         print(f"[METATRON - Round {loop + 1}]")
@@ -331,7 +328,8 @@ List all vulnerabilities, fixes, and suggest exploits where applicable."""
             print("\n[*] No tool calls. Analysis complete.")
             break
 
-        tool_results = run_tool_calls(tool_calls)
+        tool_results = run_tool_calls(tool_calls,
+                                      provider_name=provider_name, model=model)
 
         # add assistant response and tool results as new messages
         messages.append({
@@ -368,13 +366,14 @@ If analysis is complete, give the final RISK_LEVEL and SUMMARY."""
 
 if __name__ == "__main__":
     print("[ llm.py test — direct AI query ]\n")
+    print(f"  Provider: {config.ACTIVE_PROVIDER}")
+    print(f"  Model:    {config.ACTIVE_MODEL}\n")
 
-    # test if ollama is reachable
-    try:
-        r = requests.get("http://localhost:11434", timeout=5)
-        print("[+] Ollama is running.")
-    except Exception:
-        print("[!] Ollama not reachable. Run: ollama serve")
+    provider = get_provider()
+    if provider.ping():
+        print(f"[+] {provider.label()} is reachable.")
+    else:
+        print(f"[!] {provider.label()} is not reachable. Check config.")
         exit(1)
 
     target = input("Test target: ").strip()

--- a/metatron.py
+++ b/metatron.py
@@ -32,6 +32,8 @@ from db import (
 )
 from tools import interactive_tool_run, format_recon_for_llm, run_default_recon
 from llm import analyse_target
+from providers import get_provider, list_providers
+import config
 
 
 # ─────────────────────────────────────────────
@@ -39,8 +41,8 @@ from llm import analyse_target
 # ─────────────────────────────────────────────
 
 def banner():
-    os.system("clear")
-    print("""
+    os.system("cls" if os.name == "nt" else "clear")
+    print(f"""
 \033[91m
     ███╗   ███╗███████╗████████╗ █████╗ ████████╗██████╗  ██████╗ ███╗   ██╗
     ████╗ ████║██╔════╝╚══██╔══╝██╔══██╗╚══██╔══╝██╔══██╗██╔═══██╗████╗  ██║
@@ -49,7 +51,7 @@ def banner():
     ██║ ╚═╝ ██║███████╗   ██║   ██║  ██║   ██║   ██║  ██║╚██████╔╝██║ ╚████║
     ╚═╝     ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 \033[0m
-    \033[90mAI Penetration Testing Assistant  |  Model: metatron-qwen  |  Parrot OS\033[0m
+    \033[90mAI Penetration Testing Assistant  |  {config.ACTIVE_PROVIDER}/{config.ACTIVE_MODEL}  |  Parrot OS\033[0m
     \033[90m─────────────────────────────────────────────────────────────────────\033[0m
 """)
 
@@ -96,6 +98,18 @@ def confirm(question: str) -> bool:
 
 def new_scan():
     divider("NEW SCAN")
+
+    # ── provider selection ─────────────────────
+    prov_name = config.ACTIVE_PROVIDER
+    prov_model = config.ACTIVE_MODEL
+    prov_info = config.PROVIDERS.get(prov_name, {})
+    info(f"Using: {prov_info.get('name', prov_name)} / {prov_model}")
+    switch = prompt("[Enter = continue, s = switch provider]: ").lower()
+    if switch == "s":
+        result = provider_select_prompt()
+        if result:
+            prov_name, prov_model = result
+
     target = prompt("[?] Enter target IP or domain: ")
     if not target:
         warn("No target entered.")
@@ -125,7 +139,8 @@ def new_scan():
 
     # send to AI
     divider("AI ANALYSIS")
-    result = analyse_target(target, raw_scan)
+    result = analyse_target(target, raw_scan,
+                            provider_name=prov_name, model=prov_model)
 
     # ── save everything to DB ──────────────────
     divider("SAVING TO DATABASE")
@@ -376,6 +391,101 @@ def edit_delete_menu(sl_no: int):
 
 
 # ─────────────────────────────────────────────
+# PROVIDER SELECT PROMPT (inline, for per-scan switching)
+# ─────────────────────────────────────────────
+
+def provider_select_prompt():
+    """Quick inline provider/model picker. Returns (provider, model) or None."""
+    providers = list_providers()
+    print()
+    for i, p in enumerate(providers, 1):
+        key_status = "\033[92m✓\033[0m" if p["has_key"] else "\033[91m✗\033[0m"
+        active_tag = " \033[93m← active\033[0m" if p["active"] else ""
+        print(f"  [{i}] {p['name']}  {key_status}{active_tag}")
+
+    choice = prompt("Select provider [1-4]: ")
+    if not choice.isdigit() or int(choice) < 1 or int(choice) > len(providers):
+        warn("Invalid choice. Keeping current provider.")
+        return None
+
+    selected = providers[int(choice) - 1]
+    if not selected["has_key"]:
+        error(f"No API key configured for {selected['name']}.")
+        error(f"Add {config.PROVIDERS[selected['key']]['key_var']} to your .env file.")
+        return None
+
+    # model selection
+    models = selected["models"]
+    if len(models) == 1:
+        return (selected["key"], models[0])
+
+    print(f"\n  Available models for {selected['name']}:")
+    for j, m in enumerate(models, 1):
+        print(f"    [{j}] {m}")
+
+    mchoice = prompt(f"Select model [1-{len(models)}]: ")
+    if not mchoice.isdigit() or int(mchoice) < 1 or int(mchoice) > len(models):
+        warn("Invalid choice. Using first model.")
+        return (selected["key"], models[0])
+
+    return (selected["key"], models[int(mchoice) - 1])
+
+
+# ─────────────────────────────────────────────
+# SETTINGS MENU
+# ─────────────────────────────────────────────
+
+def settings_menu():
+    divider("SETTINGS")
+
+    # show current config
+    info(f"Active provider : {config.ACTIVE_PROVIDER}")
+    info(f"Active model    : {config.ACTIVE_MODEL}")
+    divider()
+
+    # show all providers
+    print("\n  \033[1mConfigured Providers:\033[0m\n")
+    providers = list_providers()
+    for p in providers:
+        key_status = "\033[92m✓ key set\033[0m" if p["has_key"] else "\033[91m✗ no key\033[0m"
+        active_tag = "  \033[93m← active\033[0m" if p["active"] else ""
+        print(f"    {p['name']:<25} {key_status}{active_tag}")
+        for m in p["models"]:
+            print(f"      └─ {m}")
+    print()
+
+    print("  [1] Switch active provider & model")
+    print("  [2] Test current provider connection")
+    print("  [3] Back")
+    divider()
+
+    choice = prompt("Choice: ")
+
+    if choice == "1":
+        result = provider_select_prompt()
+        if result:
+            prov, model = result
+            # update runtime config
+            config.ACTIVE_PROVIDER = prov
+            config.ACTIVE_MODEL    = model
+            success(f"Switched to: {config.PROVIDERS[prov]['name']} / {model}")
+            info("Note: to make this permanent, update ACTIVE_PROVIDER and ACTIVE_MODEL in .env")
+
+    elif choice == "2":
+        info(f"Testing {config.ACTIVE_PROVIDER} / {config.ACTIVE_MODEL}...")
+        provider = get_provider()
+        if provider.ping():
+            success(f"{provider.label()} is reachable!")
+        else:
+            error(f"{provider.label()} is NOT reachable. Check config / API key / network.")
+
+    elif choice == "3":
+        return
+    else:
+        warn("Invalid choice.")
+
+
+# ─────────────────────────────────────────────
 # DB CONNECTION CHECK
 # ─────────────────────────────────────────────
 
@@ -383,11 +493,11 @@ def check_db():
     try:
         conn = get_connection()
         conn.close()
-        return True
+        success("MariaDB connection OK.")
     except Exception as e:
-        error(f"MariaDB connection failed: {e}")
-        error("Make sure MariaDB is running: sudo systemctl start mariadb")
-        return False
+        error(f"Cannot connect to MariaDB: {e}")
+        error("Make sure MariaDB is running. Exiting.")
+        sys.exit(1)
 
 
 # ─────────────────────────────────────────────
@@ -399,7 +509,8 @@ def main_menu():
         banner()
         print("  \033[92m[1]\033[0m  New Scan")
         print("  \033[92m[2]\033[0m  View History")
-        print("  \033[92m[3]\033[0m  Exit")
+        print("  \033[92m[3]\033[0m  Settings")
+        print("  \033[92m[4]\033[0m  Exit")
         divider()
 
         choice = prompt("metatron> ")
@@ -413,6 +524,10 @@ def main_menu():
             input("\n\033[90mPress Enter to continue...\033[0m")
 
         elif choice == "3":
+            settings_menu()
+            input("\n\033[90mPress Enter to continue...\033[0m")
+
+        elif choice == "4":
             print("\n\033[91m[*] Shutting down Metatron. Stay legal.\033[0m\n")
             sys.exit(0)
 
@@ -425,6 +540,5 @@ def main_menu():
 # ─────────────────────────────────────────────
 
 if __name__ == "__main__":
-    if not check_db():
-        sys.exit(1)
+    check_db()
     main_menu()

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+METATRON - providers.py
+Unified LLM provider abstraction.
+Supports: Ollama (local), Anthropic (Claude), OpenAI, Google (Gemini).
+Each provider implements send() → str using a messages-based interface.
+"""
+
+from abc import ABC, abstractmethod
+import requests
+import config
+
+
+# ─────────────────────────────────────────────
+# BASE PROVIDER
+# ─────────────────────────────────────────────
+
+class BaseProvider(ABC):
+    """Abstract base for all LLM providers."""
+
+    def __init__(self, model: str, temperature: float, max_tokens: int, timeout: int):
+        self.model       = model
+        self.temperature = temperature
+        self.max_tokens  = max_tokens
+        self.timeout     = timeout
+
+    @abstractmethod
+    def send(self, messages: list) -> str:
+        """Send a list of message dicts and return the response text.
+        messages: [{"role": "system"|"user"|"assistant", "content": "..."}]
+        """
+        ...
+
+    @abstractmethod
+    def ping(self) -> bool:
+        """Quick health check — returns True if provider is reachable."""
+        ...
+
+    def label(self) -> str:
+        return f"{self.__class__.__name__}({self.model})"
+
+
+# ─────────────────────────────────────────────
+# OLLAMA (LOCAL)
+# ─────────────────────────────────────────────
+
+class OllamaProvider(BaseProvider):
+
+    def __init__(self, model: str, temperature: float, max_tokens: int, timeout: int):
+        super().__init__(model, temperature, max_tokens, timeout)
+        self.url = config.OLLAMA_URL
+
+    def send(self, messages: list) -> str:
+        try:
+            payload = {
+                "model":  self.model,
+                "messages": messages,
+                "stream": False,
+                "options": {
+                    "num_predict":  self.max_tokens,
+                    "temperature":  self.temperature,
+                    "top_p":        0.9,
+                }
+            }
+            print(f"\n[*] Sending to {self.model} (Ollama)...")
+            resp = requests.post(self.url, json=payload, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+            response = data.get("message", {}).get("content", "").strip()
+            return response or "[!] Model returned empty response."
+
+        except requests.exceptions.ConnectionError:
+            return "[!] Cannot connect to Ollama. Is it running? Try: ollama serve"
+        except requests.exceptions.Timeout:
+            return "[!] Ollama timed out. Model may be loading, try again."
+        except requests.exceptions.HTTPError as e:
+            return f"[!] Ollama HTTP error: {e}"
+        except Exception as e:
+            return f"[!] Unexpected error: {e}"
+
+    def ping(self) -> bool:
+        try:
+            base = self.url.rsplit("/api", 1)[0]
+            r = requests.get(base, timeout=5)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+
+# ─────────────────────────────────────────────
+# ANTHROPIC (CLAUDE)
+# ─────────────────────────────────────────────
+
+class AnthropicProvider(BaseProvider):
+
+    def send(self, messages: list) -> str:
+        try:
+            import anthropic
+        except ImportError:
+            return "[!] anthropic SDK not installed. Run: pip install anthropic"
+
+        api_key = config.get_api_key("anthropic")
+        if not api_key:
+            return "[!] ANTHROPIC_API_KEY not set in .env"
+
+        try:
+            client = anthropic.Anthropic(api_key=api_key)
+            print(f"\n[*] Sending to {self.model} (Anthropic)...")
+
+            # Anthropic uses system as a top-level param, not in messages
+            system_text = ""
+            user_messages = []
+            for msg in messages:
+                if msg["role"] == "system":
+                    system_text = msg["content"]
+                else:
+                    user_messages.append(msg)
+
+            kwargs = {
+                "model":      self.model,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+                "messages":   user_messages,
+            }
+            if system_text:
+                kwargs["system"] = system_text
+
+            message = client.messages.create(**kwargs)
+            text = message.content[0].text.strip()
+            return text or "[!] Model returned empty response."
+
+        except anthropic.AuthenticationError:
+            return "[!] Anthropic API key is invalid."
+        except anthropic.RateLimitError:
+            return "[!] Anthropic rate limit exceeded. Wait and retry."
+        except anthropic.APIError as e:
+            return f"[!] Anthropic API error: {e}"
+        except Exception as e:
+            return f"[!] Unexpected error (Anthropic): {e}"
+
+    def ping(self) -> bool:
+        try:
+            import anthropic
+            api_key = config.get_api_key("anthropic")
+            if not api_key:
+                return False
+            client = anthropic.Anthropic(api_key=api_key)
+            client.models.list(limit=1)
+            return True
+        except Exception:
+            return False
+
+
+# ─────────────────────────────────────────────
+# OPENAI
+# ─────────────────────────────────────────────
+
+class OpenAIProvider(BaseProvider):
+
+    def send(self, messages: list) -> str:
+        try:
+            from openai import OpenAI
+        except ImportError:
+            return "[!] openai SDK not installed. Run: pip install openai"
+
+        api_key = config.get_api_key("openai")
+        if not api_key:
+            return "[!] OPENAI_API_KEY not set in .env"
+
+        try:
+            client = OpenAI(api_key=api_key)
+            print(f"\n[*] Sending to {self.model} (OpenAI)...")
+
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=messages,
+                max_completion_tokens=self.max_tokens,
+                temperature=self.temperature,
+            )
+            text = response.choices[0].message.content.strip()
+            return text or "[!] Model returned empty response."
+
+        except Exception as e:
+            err = str(e)
+            if "authentication" in err.lower() or "api key" in err.lower():
+                return "[!] OpenAI API key is invalid."
+            if "rate" in err.lower():
+                return "[!] OpenAI rate limit exceeded. Wait and retry."
+            return f"[!] OpenAI error: {e}"
+
+    def ping(self) -> bool:
+        try:
+            from openai import OpenAI
+            api_key = config.get_api_key("openai")
+            if not api_key:
+                return False
+            client = OpenAI(api_key=api_key)
+            client.models.list()
+            return True
+        except Exception:
+            return False
+
+
+# ─────────────────────────────────────────────
+# GOOGLE (GEMINI)
+# ─────────────────────────────────────────────
+
+class GoogleProvider(BaseProvider):
+
+    def send(self, messages: list) -> str:
+        try:
+            from google import genai
+        except ImportError:
+            return "[!] google-genai SDK not installed. Run: pip install google-genai"
+
+        api_key = config.get_api_key("google")
+        if not api_key:
+            return "[!] GOOGLE_API_KEY not set in .env"
+
+        try:
+            client = genai.Client(api_key=api_key)
+            print(f"\n[*] Sending to {self.model} (Google Gemini)...")
+
+            # Gemini expects a flat prompt; merge system + user messages
+            parts = []
+            for msg in messages:
+                parts.append(msg["content"])
+            full_prompt = "\n\n".join(parts)
+
+            response = client.models.generate_content(
+                model=self.model,
+                contents=full_prompt,
+                config=genai.types.GenerateContentConfig(
+                    max_output_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                ),
+            )
+            text = response.text.strip()
+            return text or "[!] Model returned empty response."
+
+        except Exception as e:
+            err = str(e)
+            if "api key" in err.lower() or "403" in err:
+                return "[!] Google API key is invalid."
+            return f"[!] Google Gemini error: {e}"
+
+    def ping(self) -> bool:
+        try:
+            from google import genai
+            api_key = config.get_api_key("google")
+            if not api_key:
+                return False
+            client = genai.Client(api_key=api_key)
+            client.models.list(config={"page_size": 1})
+            return True
+        except Exception:
+            return False
+
+
+# ─────────────────────────────────────────────
+# FACTORY
+# ─────────────────────────────────────────────
+
+_PROVIDER_MAP = {
+    "ollama":    OllamaProvider,
+    "anthropic": AnthropicProvider,
+    "openai":    OpenAIProvider,
+    "google":    GoogleProvider,
+}
+
+
+def get_provider(
+    name: str = None,
+    model: str = None,
+    temperature: float = None,
+    max_tokens: int = None,
+    timeout: int = None,
+) -> BaseProvider:
+    """
+    Factory — returns a configured provider instance.
+    Falls back to config.py defaults for any parameter not given.
+    """
+    name        = name        or config.ACTIVE_PROVIDER
+    model       = model       or config.ACTIVE_MODEL
+    temperature = temperature if temperature is not None else config.TEMPERATURE
+    max_tokens  = max_tokens  or config.MAX_TOKENS
+    timeout     = timeout     or config.LLM_TIMEOUT
+
+    cls = _PROVIDER_MAP.get(name)
+    if cls is None:
+        raise ValueError(f"Unknown provider: '{name}'. Available: {list(_PROVIDER_MAP.keys())}")
+
+    return cls(
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        timeout=timeout,
+    )
+
+
+def list_providers() -> list:
+    """
+    Return a list of dicts describing each provider and its status.
+    Used by the settings menu.
+    """
+    result = []
+    for key, info in config.PROVIDERS.items():
+        has_key = config.has_api_key(key)
+        is_active = (key == config.ACTIVE_PROVIDER)
+        result.append({
+            "key":     key,
+            "name":    info["name"],
+            "models":  info["models"],
+            "has_key": has_key,
+            "active":  is_active,
+        })
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ rich==14.3.3
 soupsieve==2.8.3
 typing_extensions==4.15.0
 urllib3==2.6.3
+python-dotenv>=1.0.0
+anthropic>=0.42.0
+openai>=1.58.0
+google-genai>=1.9.0


### PR DESCRIPTION
## What

Adds support for multiple LLM providers beyond Ollama — users can now run METATRON with **OpenAI (GPT)**, **Anthropic (Claude)**, **Google (Gemini)**, or keep using **Ollama** locally. Provider switching is available both at startup and mid-session via a new Settings menu.

## Why

Ollama is great for local/offline use, but not everyone has the hardware to run large models. Cloud providers give users access to stronger models with zero setup. This also opens the door for comparing analysis quality across different LLMs.

## How

### New files
| File | Purpose |
|------|---------|
| `config.py` | Centralized configuration loaded from `.env` via `python-dotenv`. Defines active provider/model, API keys, DB credentials, and provider catalog. |
| `providers.py` | Provider abstraction layer. `BaseProvider` ABC with `send(messages)` and `ping()` methods. Concrete implementations: `OllamaProvider`, `AnthropicProvider`, `OpenAIProvider`, `GoogleProvider`. Factory function `get_provider()`. |
| `.env.example` | Template with all configuration variables and safe defaults. |

### Modified files
| File | Change |
|------|--------|
| `llm.py` | `ask_ollama()` → `ask_llm()` using the provider abstraction. `summarize_tool_output()` updated to use active provider. Preserves all upstream features (evidence gating, `_clean()`, summarizer, parser). |
| `metatron.py` | New **Settings** menu (view providers, switch active, test connection). Provider selection prompt before each scan. Banner shows active provider/model dynamically. Cross-platform terminal clear. |
| `db.py` | Uses `config.py` for DB credentials instead of hardcoded values. |
| `export.py` | Uses `config.py` for DB credentials instead of hardcoded values. |
| `requirements.txt` | Added `python-dotenv`, `anthropic`, `openai`, `google-genai`. |
| `.gitignore` | Added `.env` to prevent accidental API key leaks. |

### Architecture

User → [metatron.py](vscode-file://vscode-app/c:/Users/Windows/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [llm.py](vscode-file://vscode-app/c:/Users/Windows/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [providers.py](vscode-file://vscode-app/c:/Users/Windows/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → [Ollama | OpenAI | Claude | Gemini]
↑
[config.py](vscode-file://vscode-app/c:/Users/Windows/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (.env)


All providers implement the same `BaseProvider` interface, so `llm.py` is completely provider-agnostic. The system prompt, evidence gating rules, tool pipeline, and report generation work identically regardless of which provider is active.

## Backward Compatibility

- **Ollama remains the default** — zero config change needed for existing users
- No database schema changes
- No changes to the tool pipeline or scan logic
- `.env` file is optional; defaults match current behavior
- Cloud SDKs are optional runtime dependencies (only imported when the provider is selected)

## Setup (for cloud providers)

```bash
cp .env.example .env
# Edit .env and add your API key(s):
# ANTHROPIC_API_KEY=sk-ant-...
# OPENAI_API_KEY=sk-...
# GOOGLE_API_KEY=AIza...
