### PR TITLE
feat: add View History controls for editing and deleting sessions

### DIFF
--- a/db.py
+++ b/db.py
@@ -115,6 +115,16 @@ def get_all_history():
     return rows
 
 
+def get_history_by_sl_no(sl_no: int):
+    """Return one history row by sl_no, or None if not found."""
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute("SELECT sl_no, target, scan_date, status FROM history WHERE sl_no = %s", (sl_no,))
+    row = c.fetchone()
+    conn.close()
+    return row
+
+
 def get_session(sl_no: int) -> dict:
     """Return everything linked to a sl_no across all tables."""
     conn = get_connection()
@@ -229,6 +239,24 @@ def edit_summary_risk(sl_no: int, risk_level: str):
     conn.commit()
     conn.close()
     print(f"[+] Summary risk_level updated for SL#{sl_no}")
+
+
+def edit_history_entry(sl_no: int, field: str, value: str):
+    """Edit target or status in history for a given sl_no."""
+    allowed = {"target", "status"}
+    if field not in allowed:
+        print(f"[!] Invalid field: {field}. Allowed: {allowed}")
+        return
+
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute(
+        f"UPDATE history SET {field} = %s WHERE sl_no = %s",
+        (value, sl_no)
+    )
+    conn.commit()
+    conn.close()
+    print(f"[+] history.{field} updated for SL#{sl_no}")
 
 
 # ─────────────────────────────────────────────

--- a/metatron.py
+++ b/metatron.py
@@ -15,10 +15,12 @@ from db import (
     save_exploit,
     save_summary,
     get_all_history,
+    get_history_by_sl_no,
     get_session,
     get_vulnerabilities,
     get_fixes,
     get_exploits,
+    edit_history_entry,
     edit_vulnerability,
     edit_fix,
     edit_exploit,
@@ -180,37 +182,90 @@ def new_scan():
 # ─────────────────────────────────────────────
 
 def view_history():
-    divider("SCAN HISTORY")
-    rows = get_all_history()
+    while True:
+        divider("SCAN HISTORY")
+        rows = get_all_history()
 
-    if not rows:
-        warn("No scans in database yet.")
-        return
+        if not rows:
+            warn("No scans in database yet.")
+            return
 
-    print_history(rows)
+        print_history(rows)
+        print("  [1] View session details")
+        print("  [2] Edit history entry (target/status)")
+        print("  [3] Delete a session by SL#")
+        print("  [4] Back")
+        divider()
 
-    sl_no_str = prompt("Enter SL# to view details (or press Enter to go back): ")
-    if not sl_no_str:
-        return
+        choice = prompt("Choice: ")
 
-    try:
-        sl_no = int(sl_no_str)
-    except ValueError:
-        error("Invalid SL#.")
-        return
+        if choice == "1":
+            sl_no_str = prompt("Enter SL# to view details: ")
+            if not sl_no_str.isdigit():
+                error("Invalid SL#.")
+                continue
 
-    data = get_session(sl_no)
-    if not data["history"]:
-        error(f"SL# {sl_no} not found.")
-        return
+            sl_no = int(sl_no_str)
+            data = get_session(sl_no)
+            if not data["history"]:
+                error(f"SL# {sl_no} not found.")
+                continue
 
-    print_session(data)
+            print_session(data)
 
-    if confirm("Export this session?"):
-        export_menu(data)
+            if confirm("Export this session?"):
+                export_menu(data)
 
-    if confirm("Edit or delete anything in this session?"):
-        edit_delete_menu(sl_no)
+            if confirm("Edit or delete anything in this session?"):
+                edit_delete_menu(sl_no)
+
+        elif choice == "2":
+            sl_no_str = prompt("Enter SL# to edit history entry: ")
+            if not sl_no_str.isdigit():
+                error("Invalid SL#.")
+                continue
+
+            sl_no = int(sl_no_str)
+            row = get_history_by_sl_no(sl_no)
+            if not row:
+                error(f"SL# {sl_no} not found.")
+                continue
+
+            print(f"Current: SL# {row[0]} | target={row[1]} | date={row[2]} | status={row[3]}")
+            print("  Fields: target / status")
+            field = prompt("Field to edit: ").lower()
+            if field not in ("target", "status"):
+                error("Invalid field. Use target or status.")
+                continue
+
+            value = prompt(f"New value for '{field}': ")
+            if not value:
+                warn("Value cannot be empty.")
+                continue
+
+            edit_history_entry(sl_no, field, value)
+
+        elif choice == "3":
+            sl_no_str = prompt("Enter SL# to delete full session: ")
+            if not sl_no_str.isdigit():
+                error("Invalid SL#.")
+                continue
+
+            sl_no = int(sl_no_str)
+            row = get_history_by_sl_no(sl_no)
+            if not row:
+                error(f"SL# {sl_no} not found.")
+                continue
+
+            if confirm(f"\n\033[91mPermanently delete ENTIRE session SL# {sl_no} from all tables?\033[0m"):
+                delete_full_session(sl_no)
+                success(f"Session SL# {sl_no} wiped.")
+
+        elif choice == "4" or choice == "":
+            return
+
+        else:
+            warn("Invalid choice.")
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
**Description**  
This PR improves the CLI View History flow by adding direct control over history records.

Users can now:
1. View session details by SL#
2. Edit history entry fields (target and status)
3. Delete a full session by SL# directly from the history menu

**What Changed**
1. Refactored View History into an action-oriented submenu.
2. Added history-level DB operations:
1. Fetch history row by SL#
2. Update history entry by allowed field (target/status)
3. Reused full-session deletion in the new history flow
3. Added input validation for:
1. Invalid SL#
2. Invalid edit field
3. Empty update values

**Impact**
1. Better history usability without jumping across multiple flows.
2. Faster correction of target/status entries.
3. Centralized sensitive maintenance actions inside View History.

**Compatibility**
1. No database schema breaking changes.
2. Existing session-level edit/delete flows remain intact.

**How to Validate**
1. Open View History.
2. Test viewing a session by SL#.
3. Test editing target and status for an existing session.
4. Test invalid SL# and invalid field handling.
5. Test full session deletion and confirm removal from history list.

**Technical Validation**
1. Python syntax compilation passed for core modules.
2. No static analysis errors reported in updated files.