### PR TITLE
security: constrain redirects and tool targets

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -147,7 +147,7 @@ def summarize_tool_output(raw_output: str) -> str:
         return summary if summary else raw_output
     except Exception:
         return raw_output
-def run_tool_calls(calls: list) -> str:
+def run_tool_calls(calls: list, target: str) -> str:
     """
     Execute all tool/search calls and return combined results string.
     """
@@ -159,7 +159,7 @@ def run_tool_calls(calls: list) -> str:
         print(f"\n  [DISPATCH] {call_type}: {call_content}")
 
         if call_type == "TOOL":
-            output = run_tool_by_command(call_content)
+            output = run_tool_by_command(call_content, target)
         elif call_type == "SEARCH":
             output = handle_search_dispatch(call_content)
         else:
@@ -331,7 +331,7 @@ List all vulnerabilities, fixes, and suggest exploits where applicable."""
             print("\n[*] No tool calls. Analysis complete.")
             break
 
-        tool_results = run_tool_calls(tool_calls)
+        tool_results = run_tool_calls(tool_calls, target)
 
         # add assistant response and tool results as new messages
         messages.append({

--- a/tools.py
+++ b/tools.py
@@ -7,6 +7,8 @@ OS: Parrot OS (all these tools are pre-installed or easily available)
 """
 
 import subprocess
+import re
+from urllib.parse import urljoin, urlparse
 
 
 # ─────────────────────────────────────────────
@@ -78,27 +80,47 @@ def run_whatweb(target: str) -> str:
     return run_tool(["whatweb", "-a", "3", target], timeout=60)
 
 
+def _redirect_stays_on_target(location: str, target: str) -> bool:
+    if not location:
+        return False
+    parsed = urlparse(location)
+    if not parsed.netloc:
+        return True  # redirect relative, same host
+    return (parsed.hostname or "").lower() == target.lower()
+
+
+def _fetch_headers_no_redirect(url: str) -> tuple:
+    command = ["curl", "-sI", "--max-time", "10"]
+    if urlparse(url).scheme.lower() == "https":
+        command.append("-k")
+    result = run_tool(command + [url], timeout=20)
+    location = ""
+    for line in result.splitlines():
+        if line.lower().startswith("location:"):
+            location = line.split(":", 1)[1].strip()
+            break
+    return result, location
+
+
+def _fetch_headers_with_safe_redirect(url: str, target: str) -> str:
+    result, location = _fetch_headers_no_redirect(url)
+    if not location:
+        return result
+    if not _redirect_stays_on_target(location, target):
+        return f"[!] Redirect to different host blocked: {location}"
+    return _fetch_headers_no_redirect(urljoin(url, location))[0]
+
+
 def run_curl_headers(target: str) -> str:
     """
     curl -sI — fetch HTTP headers only
     Reveals: server software, X-Powered-By, cookies, security headers (or lack of them)
     """
     print(f"  [*] curl -sI http://{target}")
-    output = run_tool([
-        "curl", "-sI",
-        "--max-time", "10",
-        "--location",          # follow redirects
-        f"http://{target}"
-    ], timeout=20)
+    output = _fetch_headers_with_safe_redirect(f"http://{target}", target)
 
     # also try https
-    https_output = run_tool([
-        "curl", "-sI",
-        "--max-time", "10",
-        "--location",
-        "-k",                  # ignore cert errors
-        f"https://{target}"
-    ], timeout=20)
+    https_output = _fetch_headers_with_safe_redirect(f"https://{target}", target)
 
     return f"[HTTP Headers]\n{output}\n\n[HTTPS Headers]\n{https_output}"
 
@@ -190,8 +212,27 @@ def format_recon_for_llm(results: dict) -> str:
 
 
 ALLOWED_TOOLS = {"nmap", "whois", "whatweb", "curl", "dig", "nikto"}
+_IP_OR_HOST_RE = re.compile(
+    r'^(?:\d{1,3}(?:\.\d{1,3}){3}|[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?'
+    r'(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)+)$'
+)
 
-def run_tool_by_command(command_str: str) -> str:
+
+def _looks_like_host(arg: str):
+    candidate = arg
+    if "://" in arg:
+        candidate = urlparse(arg).hostname or ""
+    if not candidate or candidate.startswith("-"):
+        return None
+    return candidate if _IP_OR_HOST_RE.match(candidate) else None
+
+
+def _matches_target(host: str, target: str) -> bool:
+    host, target = host.lower(), target.lower()
+    return host == target or host.endswith("." + target)
+
+
+def run_tool_by_command(command_str: str, target: str) -> str:
     parts = command_str.strip().split()
     if not parts:
         return "[!] Empty command."
@@ -200,6 +241,14 @@ def run_tool_by_command(command_str: str) -> str:
     tool = parts[0].lower().split("/")[-1]  # handles /bin/nmap etc
     if tool not in ALLOWED_TOOLS:
         return f"[!] Tool '{parts[0]}' is not permitted. Allowed: {ALLOWED_TOOLS}"
+
+    for arg in parts[1:]:
+        host = _looks_like_host(arg)
+        if host and not _matches_target(host, target):
+            return (
+                f"[!] Blocked: argument '{arg}' targets '{host}', which is outside "
+                f"the authorized session target '{target}'. Tool not run."
+            )
     
     return run_tool(parts)
 


### PR DESCRIPTION
## Summary

Fixes two related security issues in the LLM-driven tool execution path:

- SSRF through cross-host HTTP(S) redirects in `tools.py`.
- Session target bypass through host-like arguments in `[TOOL: ...]` commands dispatched by `llm.py`.

## Root causes

`tools.py::run_curl_headers` used `curl --location` for both HTTP and HTTPS. A target-controlled redirect could therefore send the request to a different host, including localhost or cloud metadata endpoints, with the request headers handled by curl.

`tools.py::run_tool_by_command` previously allowlisted only the executable name. Because the LLM writes the `[TOOL: ...]` tag and consumes reconnaissance output that can contain target-controlled text, an injected instruction could cause a subsequent command to target another IP or domain. `llm.py::run_tool_calls` also did not pass the session target into the dispatcher.

## Fix and design decisions

- Header fetches now start without `--location` and inspect the first `Location` header.
- Relative redirects and redirects whose hostname exactly matches the original target are followed once; cross-host redirects are replaced with `[!] Redirect to different host blocked: <location>`. HTTPS retains `-k` for certificate handling, which is unrelated to SSRF.
- The redirect protection is host-match based rather than private-range blocking. Private IPs remain valid targets for this project's authorized internal-use cases; only a redirect that leaves the original target host is blocked.
- `run_tool_by_command(command_str, target)` now checks arguments after the allowlisted binary. `_looks_like_host` recognizes dotted IPv4-shaped values, multi-label DNS hostnames, and URLs, while ignoring flags, bare ports, and non-host script/option names to avoid false positives. `_matches_target` permits the exact target and its subdomains. This deliberately does not claim to validate every possible address syntax or DNS resolution; it scopes the common host-like argument forms without blocking ordinary tool arguments.
- `llm.py::run_tool_calls(calls, target)` and `analyse_target` now thread the session target through the dispatch path.

## Validation

### Focused security regressions

- Simulated a `Location` header to `169.254.169.254`: blocked and no follow-up request was made.
- Simulated a relative/same-host `Location`: followed exactly once.
- Confirmed no curl invocation uses `--location`; HTTPS still includes `-k`.
- `run_tool_by_command("nmap -sV 1.2.3.4", "example.com")` returned the required block message without executing `run_tool`.
- `run_tool_by_command("nmap -sV -T4 --open example.com", "example.com")` passed target validation and executed normally under a mocked runner.

### Real authorized target validation

- Ran `nmap -sV -T4 --open alpine-emachines.local.homelan` through `run_tool_by_command` with the same target as the session. It executed successfully against the authorized internal host `192.168.40.157` and returned real service data: OpenSSH 10.2, rpcbind, Samba 4.6.2, and NFS.
- Ran `metatron.py` end to end against that same internal target using the real MariaDB schema and Ollama integration. Session creation, curl recon, result persistence, and the final saved summary completed successfully as `SL#1`; the local model exceeded the application's configured 600-second `OLLAMA_TIMEOUT` and returned the application's handled `Ollama timed out`/`UNKNOWN` result, with no crash in the security changes.


Closes #32
Closes #33