### PR TITLE
fix: make Ollama timeouts configurable

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -7,6 +7,7 @@ Model: metatron-qwen (fine-tuned from huihui_ai/qwen3.5-abliterated:9b)
 """
 
 import re
+import os
 import requests
 import json
 from tools import run_tool_by_command, run_nmap, run_curl_headers
@@ -16,7 +17,8 @@ OLLAMA_URL  = "http://localhost:11434/api/chat"
 MODEL_NAME  = "metatron-qwen"
 MAX_TOKENS = 8192
 MAX_TOOL_LOOPS = 9   # max times AI can call tools per session
-OLLAMA_TIMEOUT = 600 
+OLLAMA_TIMEOUT = int(os.environ.get("METATRON_OLLAMA_TIMEOUT", "600"))
+SUMMARY_TIMEOUT = int(os.environ.get("METATRON_SUMMARY_TIMEOUT", "120"))
 
 # ─────────────────────────────────────────────
 # SYSTEM PROMPT
@@ -141,7 +143,7 @@ def summarize_tool_output(raw_output: str) -> str:
                 "top_p": 0.9,
             }
         }
-        resp = requests.post(OLLAMA_URL, json=payload, timeout=120)
+        resp = requests.post(OLLAMA_URL, json=payload, timeout=SUMMARY_TIMEOUT)
         resp.raise_for_status()
         summary = resp.json().get("message", {}).get("content", "").strip()
         return summary if summary else raw_output


### PR DESCRIPTION
## Summary

Make the two Ollama request timeouts configurable through environment variables while preserving the existing defaults and behavior for users who do not configure them.

## Root cause

`llm.py:19` hardcoded the main `ask_ollama()` request timeout to 600 seconds. Separately, `summarize_tool_output()` around `llm.py:144` used its own hardcoded 120-second timeout. These values were inconsistent, and the shorter summarizer timeout could expire while the Ollama server continued processing the request. The timeout issue was reported in issue #21; several users had been editing the source manually to use values such as 900 or 1200 seconds.

## Fix

- Add `METATRON_OLLAMA_TIMEOUT`, defaulting to `600`.
- Add `METATRON_SUMMARY_TIMEOUT`, defaulting to `120`.
- Use `SUMMARY_TIMEOUT` for the summarizer request.

With no environment variables set, the effective timeouts remain exactly 600/120 and there is no behavior change.

## Validation

### Mocked validation

- Confirmed the default path reads `OLLAMA_TIMEOUT == 600` and `SUMMARY_TIMEOUT == 120`.
- Set both environment variables to `5` before importing `llm.py` and confirmed both module constants became `5`.
- Mocked `requests.post` to raise `requests.exceptions.Timeout`; `ask_ollama()` returned `[!] Ollama timed out. Model may be loading, try again.` without crashing.
- Confirmed `summarize_tool_output()` passed `timeout=5` to `requests.post` and gracefully returned the raw output when the mocked request timed out.
- `python3 -m py_compile llm.py` and `git diff --check` passed.

### Real validation

Against the authorized internal target `alpine-emachines.local.homelan`, using `METATRON_OLLAMA_TIMEOUT=1800` and `METATRON_SUMMARY_TIMEOUT=900`: 

- Loop round 1 completed with a real analysis in 585 seconds.
- Loop round 2 was a new legitimate model-requested tool-call round, not a retry; the accumulated prompt had grown to 3109 tokens. It did not complete after approximately 50 minutes and was terminated manually.
- The observations do not establish with certainty whether the programmatic `requests.post(timeout=900)` fired but failed to propagate cleanly in this specific path, or whether it did not fire; this remains an honest limitation of the run.

The context growth across loop rounds is a separate structural follow-up outside this configurability patch. This PR does not claim to solve that issue.

This upstream PR closes [issue #21](https://github.com/sooryathejas/METATRON/issues/21) because the requested configurability is implemented here and the default behavior remains unchanged.

Closes #21